### PR TITLE
[Freemoji] Add 56px emoji size, add name/quality arguments to non-hyperlink emoji

### DIFF
--- a/plugins/freemoji/src/Settings.tsx
+++ b/plugins/freemoji/src/Settings.tsx
@@ -10,6 +10,7 @@ const sizeOptions = {
     Tiny: 16,
     Small: 32,
     Medium: 48,
+    Big: 56,
     Large: 64,
     Huge: 96,
     Jumbo: 128,

--- a/plugins/freemoji/src/msgProcessor.ts
+++ b/plugins/freemoji/src/msgProcessor.ts
@@ -29,7 +29,7 @@ function extractUnusableEmojis(messageString: string, size: number) {
 			if (storage.hyperlink === true) {
 				emojiUrls.push(`[${emojiString[1]}](https://cdn.discordapp.com/emojis/${emojiString[2]}.${ext}?size=${size}&quality=lossless&name=${emojiString[1]})`);
 			} else {
-				emojiUrls.push(`https://cdn.discordapp.com/emojis/${emojiString[2]}.${ext}?size=${size}`);
+				emojiUrls.push(`https://cdn.discordapp.com/emojis/${emojiString[2]}.${ext}?size=${size}&quality=lossless&name=${emojiString[1]}`);
 			}
 		}
 	}


### PR DESCRIPTION
Solves https://github.com/Rico040/bunny-plugins/issues/2 (ngl my main issue was that I didn't know what to name the size lmao, but I think "Big" looks fine unless you have a better idea).

Also added the name + lossless argument to the url even when hyperlink emojis are disabled. The name argument is useful for Vencord's Transform Emoji option to show the emoji name instead of "FakeNitroEmoji" (did a similar PR to Aliucord's emoji plugin earler this year https://github.com/X1nto/AliucordPlugins/pull/53).